### PR TITLE
loading test package; no-argument testPackage(); misc

### DIFF
--- a/R/testPackage.R
+++ b/R/testPackage.R
@@ -42,26 +42,27 @@ testPackage <- function(pkgname = NULL,
         } else list()
     }
 
-    if (useSourceTests) {
+    if (is.null(pkgname) || useSourceTests) {
         root <- packageRoot(path)
         if (is.null(root))
-            stop("could not find package root directory")
+            stop("could not infer package root directory")
 
         pkgname0 <- packageInfo(root)$Package
-        if (!is.null(pkgname) && !identical(pkgname, pkgname0))
+        if (is.null(pkgname)) {
+            pkgname <- pkgname0
+        } else if (!identical(pkgname, pkgname0)) {
             stop("'pkgname' and inferred DESCRIPTION 'Package' differ")
-        pkgname <- pkgname0
-
-        dir <- file.path(root, subdir)
-        if (!file.exists(dir))          # try inst/subdir
-            dir <- file.path(root, "inst", subdir)
+        }
     } else {
-        if (is.null(pkgname))
-            stop("'pkgname' required when using installed tests")
-        library(pkgname, character.only = TRUE, quietly=TRUE)
-        dir <- system.file(subdir, package=pkgname)
+        root <- system.file(package=pkgname)
     }
 
+    library(pkgname, character.only = TRUE, quietly=TRUE)
+
+    dir <- file.path(root, subdir)
+    if (!file.exists(dir)) {            # try inst/subdir
+        dir <- file.path(root, "inst", subdir)
+    }
     if (!file.exists(dir)) {
         stop("unable to find unit tests, no subdir ", sQuote(subdir))
     }


### PR DESCRIPTION
I wasn't sure whether in a new interactive session, in the package directory, either of these should work

```
~/tmp/jimhester/BiocGenerics$ R
Bioconductor version 3.1 (BiocInstaller 1.17.7), ?biocLite for help
> BiocGenerics:::testPackage()
## ...
> BiocGenerics:::testPackage("BiocGenerics")
```

They both fail because the BiocGenerics package is not loaded.

Also, the feature (invoking testPackage() without naming the package) seems kind of convenient even in non-interactive mode, e.g.,

```
~/tmp/jimhester/BiocGenerics$ R -e "BiocGenerics:::testPackage()"
```

I made these and other changes, notably changing the useInstalled argument to useSourceTests, first to get the notion of tests (I kept getting confused that useInstalled referred to the package, rather than the tests) and then to avoid the negation !interactive() which I always had to work through...
